### PR TITLE
mavlink: change mavlink output destination

### DIFF
--- a/app/dashcam/src/main_flow/ArduPilot/dev_console.c
+++ b/app/dashcam/src/main_flow/ArduPilot/dev_console.c
@@ -966,6 +966,12 @@ static void check_wifi_txt(void)
         if (strcmp(name, "CHANNEL") == 0) {
             channel = atoi(value);
         }
+
+        if (strcmp(name, "MAVLINK_DST_IP") == 0) {
+            mavlink_set_dst_ip(inet_addr(value));
+        } else if (strcmp(name, "MAVLINK_DST_PORT") == 0) {
+            mavlink_set_dst_port(atoi(value));
+        }
     }
 
     WiFi_QueryAndSet(SET_BEACON_OFF, NULL, NULL);

--- a/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.c
+++ b/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.c
@@ -47,6 +47,8 @@ static int sitl_sock = -1;
 static char stm32_id[40];
 static bool rc_ok;
 static bool vehicle_armed;
+static uint32_t mavlink_dst_ip = INADDR_BROADCAST;
+static uint16_t mavlink_dst_port = MAVLINK_DEST_PORT;
 
 #define QUEUE_SIZE 50*1024
 
@@ -237,8 +239,8 @@ static void send_mavlink_wifi(int fd, mavlink_message_t *msg)
         memset(&addr, 0x0, sizeof(addr));
 
         addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
-        addr.sin_port = htons(MAVLINK_DEST_PORT);
+        addr.sin_addr.s_addr = mavlink_dst_ip;
+        addr.sin_port = htons(mavlink_dst_port);
         
         //console_printf("sending pkt of len %u\n", len);
         sendto(fd, buf, len, 0, (struct sockaddr*)&addr, sizeof(addr));
@@ -1472,6 +1474,16 @@ void mavlink_set_sitl(bool enable)
         }
     }
     console_printf("mavlink_sitl=%s\n", enable?"true":"false");
+}
+
+void mavlink_set_dst_ip(uint32_t ip)
+{
+    mavlink_dst_ip = ip;
+}
+
+void mavlink_set_dst_port(uint16_t port)
+{
+    mavlink_dst_port = port;
 }
 
 enum FlightCommand {

--- a/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.h
+++ b/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.h
@@ -11,6 +11,8 @@ void mavlink_show_stats(void);
 void mavlink_set_debug(uint8_t debug_level);
 int mavlink_set_flight_response(int index, int value);
 void mavlink_set_sitl(bool enable);
+void mavlink_set_dst_ip(uint32_t ip);
+void mavlink_set_dst_port(uint16_t port);
 int mavlink_fc_send(mavlink_message_t *msg);
 bool toggle_recording(void);
 bool take_snapshot(void);


### PR DESCRIPTION
maybe related to #3 

It allows user to add MAVLINK_DST_IP and MAVLINK_DST_PORT  in WIFI.TXT to change mavlink output destination 

In a swarm setup, drones are config to WiFi station mode, drones and GCS are connected to the same WiFi AP. If all drones broadcast mavlink to the same port 14550. It will create lots of traffic and each drone will spend unnecessary time to parse every packet (drone listen on 14550, so each drone will listen all broadcast packets from other drone). It may cause drone miss packets from GCS. 

User can add MAVLINK_DST_IP and MAVLINK_DST_PORT in WIFI.TXT to specific output destination. Default value (broadcast to 14550) will be used if not specified.

For example, PC running GCS is act as WiFi AP  (192.168.1.1). drones can be config to send mavlink to 192.168.1.1 on different port. It makes swarm setup easier.  

Test flight video is [here](https://youtu.be/FjuC1mN8nU4)
2 skyviper v2450, one output to GCS_IP:14550, another output to GCS_IP:14551. Two mavproxy is acted as GCS on the same PC
