### PR TITLE
Trigger snapshot on MAVLINK_MSG_ID_CAMERA_FEEDBACK message

### DIFF
--- a/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.c
+++ b/app/dashcam/src/main_flow/ArduPilot/mavlink_wifi.c
@@ -808,6 +808,15 @@ static bool mavlink_handle_msg(const mavlink_message_t *msg)
         break;
     }
         
+    case MAVLINK_MSG_ID_CAMERA_FEEDBACK: {
+      // Piggyback on GCS message to trigger camera from ardupilot mission
+      if (!disable_sd_save) {
+	take_snapshot();
+      }
+      send_named_int("VNOTIFY", 1);
+        break;
+    }
+        
     default:
 	break;
     }


### PR DESCRIPTION
This allows camera control waypoints to work.  Even with standard
unmodified ardupilot.